### PR TITLE
Avoid NPE while mDataList is null

### DIFF
--- a/adapter/src/main/java/kale/adapter/CommonAdapter.java
+++ b/adapter/src/main/java/kale/adapter/CommonAdapter.java
@@ -75,7 +75,7 @@ public abstract class CommonAdapter<T> extends BaseAdapter implements IAdapter<T
 
     @Override
     public int getCount() {
-        return mDataList.size();
+        return mDataList == null ? 0 : mDataList.size();
     }
 
     @Override

--- a/adapter/src/main/java/kale/adapter/CommonPagerAdapter.java
+++ b/adapter/src/main/java/kale/adapter/CommonPagerAdapter.java
@@ -71,7 +71,7 @@ public abstract class CommonPagerAdapter<T> extends BasePagerAdapter<View> imple
 
     @Override
     public int getCount() {
-        return mDataList.size();
+        return mDataList == null ? 0 : mDataList.size();
     }
 
     @NonNull

--- a/adapter/src/main/java/kale/adapter/CommonRcvAdapter.java
+++ b/adapter/src/main/java/kale/adapter/CommonRcvAdapter.java
@@ -73,7 +73,7 @@ public abstract class CommonRcvAdapter<T> extends RecyclerView.Adapter implement
 
     @Override
     public int getItemCount() {
-        return mDataList.size();
+        return mDataList == null ? 0 : mDataList.size();
     }
 
     @Override


### PR DESCRIPTION
although setData() was annotated with @NonNull, but when setData() with a null reference it will not show lint message. So make a null check at getItemCount() is needed.
